### PR TITLE
[Has still Errror] Allow Dictionary Compressed columns with null values emit dictionary values. 

### DIFF
--- a/src/include/duckdb/function/compression_function.hpp
+++ b/src/include/duckdb/function/compression_function.hpp
@@ -230,6 +230,12 @@ public:
 	      serialize_state(serialize_state), deserialize_state(deserialize_state), visit_block_ids(visit_block_ids) {
 	}
 
+public:
+	//! Whether the validity mask must be scanned separately when scanning the data
+	bool RequiredValidityScan() const {
+		return validity_scan == CompressionValidity::REQUIRES_VALIDITY;
+	}
+
 	//! Compression type
 	CompressionType type;
 	//! The data type this function can compress
@@ -308,8 +314,14 @@ public:
 	compression_get_segment_info_t get_segment_info = nullptr;
 
 	//! Whether the validity mask should be separately compressed
-	//! or this compression function can also be used to decompress the validity
-	CompressionValidity validity = CompressionValidity::REQUIRES_VALIDITY;
+	//! or this compression function can also be used to decompress the validity when writing
+	CompressionValidity validity_write = CompressionValidity::REQUIRES_VALIDITY;
+
+	//! Whether we need to scan the validity mask when scanning the data.
+	//! This can be distinct from validity_write as e.g., for DICTIONARY_COMPRESSION: Here, we still write
+	//! validity data to be backward compatible but don't need to read it as the dictionary itself
+	//! also encodes validity.
+	CompressionValidity validity_scan = CompressionValidity::REQUIRES_VALIDITY;
 };
 
 //! The set of compression functions

--- a/src/include/duckdb/storage/compression/dictionary/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/decompression.hpp
@@ -11,9 +11,11 @@ namespace duckdb {
 struct CompressedStringScanState : public StringScanState {
 public:
 	explicit CompressedStringScanState(BufferHandle &&handle_p)
-	    : StringScanState(), owned_handle(std::move(handle_p)), handle(owned_handle), invalid_value_sel(STANDARD_VECTOR_SIZE) {
+	    : StringScanState(), owned_handle(std::move(handle_p)), handle(owned_handle),
+	      invalid_value_sel(STANDARD_VECTOR_SIZE) {
 	}
-	explicit CompressedStringScanState(BufferHandle &handle_p) : StringScanState(), owned_handle(), handle(handle_p), invalid_value_sel(STANDARD_VECTOR_SIZE) {
+	explicit CompressedStringScanState(BufferHandle &handle_p)
+	    : StringScanState(), owned_handle(), handle(handle_p), invalid_value_sel(STANDARD_VECTOR_SIZE) {
 	}
 
 public:

--- a/src/include/duckdb/storage/compression/dictionary/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/decompression.hpp
@@ -11,9 +11,9 @@ namespace duckdb {
 struct CompressedStringScanState : public StringScanState {
 public:
 	explicit CompressedStringScanState(BufferHandle &&handle_p)
-	    : StringScanState(), owned_handle(std::move(handle_p)), handle(owned_handle) {
+	    : StringScanState(), owned_handle(std::move(handle_p)), handle(owned_handle), invalid_value_sel(STANDARD_VECTOR_SIZE) {
 	}
-	explicit CompressedStringScanState(BufferHandle &handle_p) : StringScanState(), owned_handle(), handle(handle_p) {
+	explicit CompressedStringScanState(BufferHandle &handle_p) : StringScanState(), owned_handle(), handle(handle_p), invalid_value_sel(STANDARD_VECTOR_SIZE) {
 	}
 
 public:
@@ -45,6 +45,9 @@ public:
 	idx_t dictionary_size;
 	StringDictionaryContainer dict;
 	idx_t block_size;
+
+	//! Have a selection vector to track null values when scanning to a flat vector
+	SelectionVector invalid_value_sel;
 };
 
 } // namespace duckdb

--- a/src/storage/compression/dict_fsst.cpp
+++ b/src/storage/compression/dict_fsst.cpp
@@ -240,7 +240,8 @@ CompressionFunction DictFSSTCompressionFun::GetFunction(PhysicalType data_type) 
 	    dict_fsst::DictFSSTCompressionStorage::StringScanPartial<false>,
 	    dict_fsst::DictFSSTCompressionStorage::StringFetchRow, UncompressedFunctions::EmptySkip,
 	    UncompressedStringStorage::StringInitSegment);
-	res.validity = CompressionValidity::NO_VALIDITY_REQUIRED;
+	res.validity_write = CompressionValidity::NO_VALIDITY_REQUIRED;
+	res.validity_scan = CompressionValidity::NO_VALIDITY_REQUIRED;
 	res.select = dict_fsst::DictFSSTSelect;
 	res.filter = dict_fsst::DictFSSTFilter;
 	return res;

--- a/src/storage/compression/dictionary/decompression.cpp
+++ b/src/storage/compression/dictionary/decompression.cpp
@@ -80,12 +80,25 @@ void CompressedStringScanState::ScanToFlatVector(Vector &result, idx_t result_of
 	BitpackingPrimitives::UnPackBuffer<sel_t>(data_ptr_cast(sel_vec_ptr), src, decompress_count, current_width);
 
 	auto result_data = FlatVector::Writer<string_t>(result, scan_count, result_offset);
+	idx_t invalid_value_count = 0;
+
 	for (idx_t i = 0; i < scan_count; i++) {
 		// Lookup dict offset in index buffer
 		auto string_number = sel_vec->get_index(i + start_offset);
 		auto dict_offset = index_buffer_ptr[string_number];
 		auto str_len = GetStringLength(UnsafeNumericCast<sel_t>(string_number));
 		result_data.WriteStringRef(FetchStringFromDict(UnsafeNumericCast<int32_t>(dict_offset), str_len));
+		invalid_value_sel.set_index(invalid_value_count, i + result_offset);
+		invalid_value_count += string_number == 0;
+	}
+
+	if (invalid_value_count > 0) {
+		auto &result_validity = FlatVector::ValidityMutable(result);
+		result_validity.EnsureWritable();
+		for (idx_t i = 0; i < invalid_value_count; i++) {
+			const idx_t row_idx = invalid_value_sel.get_index(i);
+			result_validity.SetInvalidUnsafe(row_idx);
+		}
 	}
 }
 

--- a/src/storage/compression/dictionary_compression.cpp
+++ b/src/storage/compression/dictionary_compression.cpp
@@ -164,7 +164,7 @@ void DictionaryCompressionStorage::StringFetchRow(ColumnSegment &segment, Column
 // Get Function
 //===--------------------------------------------------------------------===//
 CompressionFunction DictionaryCompressionFun::GetFunction(PhysicalType data_type) {
-	return CompressionFunction(
+	auto res = CompressionFunction(
 	    CompressionType::COMPRESSION_DICTIONARY, data_type, DictionaryCompressionStorage ::StringInitAnalyze,
 	    DictionaryCompressionStorage::StringAnalyze, DictionaryCompressionStorage::StringFinalAnalyze,
 	    DictionaryCompressionStorage::InitCompression, DictionaryCompressionStorage::Compress,
@@ -172,6 +172,12 @@ CompressionFunction DictionaryCompressionFun::GetFunction(PhysicalType data_type
 	    DictionaryCompressionStorage::StringScan, DictionaryCompressionStorage::StringScanPartial<false>,
 	    DictionaryCompressionStorage::StringFetchRow, UncompressedFunctions::EmptySkip,
 	    UncompressedStringStorage::StringInitSegment);
+	// for dictionary, we still want to write the validity segments to be backwards compatible with older versions,
+	// but we don't need to read it as for dictionary compression index 0 is already reserved for null, and there the
+	// dictionary compression can represent validity.
+	res.validity_write = CompressionValidity::REQUIRES_VALIDITY;
+	res.validity_scan = CompressionValidity::NO_VALIDITY_REQUIRED;
+	return res;
 }
 
 bool DictionaryCompressionFun::TypeIsSupported(const PhysicalType physical_type) {

--- a/src/storage/table/column_data_checkpointer.cpp
+++ b/src/storage/table/column_data_checkpointer.cpp
@@ -311,7 +311,7 @@ bool ColumnDataCheckpointer::ValidityCoveredByBasedata(vector<CheckpointAnalyzeR
 	}
 	auto &base = result[0];
 	D_ASSERT(base.function);
-	return base.function->validity == CompressionValidity::NO_VALIDITY_REQUIRED;
+	return base.function->validity_write == CompressionValidity::NO_VALIDITY_REQUIRED;
 }
 
 void ColumnDataCheckpointer::WriteToDisk() { // Analyze the candidate functions to select one of them to use for

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -65,7 +65,8 @@ idx_t StandardColumnData::Scan(TransactionData transaction, idx_t vector_index, 
 	const bool has_compression_function = this->GetCompressionFunction() != nullptr;
 	const bool compression_needs_validity =
 	    has_compression_function && this->GetCompressionFunction()->RequiredValidityScan();
-	if (!has_compression_function || compression_needs_validity) {
+	const bool validity_has_updates = validity->HasUpdates();
+	if (!has_compression_function || compression_needs_validity || validity_has_updates) {
 		validity->ScanVector(transaction, vector_index, state.child_states[0], result, target_count, scan_type,
 		                     state.update_scan_type);
 		D_ASSERT(state.offset_in_column == state.child_states[0].offset_in_column);

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -58,12 +58,18 @@ void StandardColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t 
 
 idx_t StandardColumnData::Scan(TransactionData transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
                                idx_t target_count) {
-	D_ASSERT(state.offset_in_column == state.child_states[0].offset_in_column);
 	auto scan_type = GetVectorScanType(state, target_count, result);
 	auto scan_count =
 	    ScanVector(transaction, vector_index, state, result, target_count, scan_type, state.update_scan_type);
-	validity->ScanVector(transaction, vector_index, state.child_states[0], result, target_count, scan_type,
-	                     state.update_scan_type);
+
+	const bool has_compression_function = this->GetCompressionFunction() != nullptr;
+	const bool compression_needs_validity =
+	    has_compression_function && this->GetCompressionFunction()->RequiredValidityScan();
+	if (!has_compression_function || compression_needs_validity) {
+		validity->ScanVector(transaction, vector_index, state.child_states[0], result, target_count, scan_type,
+		                     state.update_scan_type);
+		D_ASSERT(state.offset_in_column == state.child_states[0].offset_in_column);
+	}
 	return scan_count;
 }
 


### PR DESCRIPTION
Error: This has still a problem if there are updates to a segment, somehow the validity becomes releant again and needs to be scanned. e.g. `update_string_null_merge_dict_fsst.test` fails when running with `-DALTERNATIVE_VERIFY=1`

---


This PR enables `DICTIONARY_COMPRESSED` columns to be emitted as dictionary vectors. Previously, for each dictionary vector scanned, its corresponding validity mask was also scanned, which flattened the vector before applying the mask. 

However, since the introduction of dictionary compression in https://github.com/duckdb/duckdb/pull/3109, index 0 has always been used to encode `NULL` values. Therefore, in theory, dictionary compression itself already handles the null encoding. 

With this PR, I would propose changing the dictionary scan code to handle setting null values itself. 

Based on this, I split the previous `CompressionValidity validity  =  REQUIRES_VALIDITY /  NO_VALIDITY_REQUIRED;` flag into a `validity_write` and a `validity_scan`. 

E.g., `DICT_FSST` now has `NO_VALIDITY_REQUIRED` for both write and scan paths, while Dictionary does not need a validity mask during scan but will still write it. Therefore, also after this change, previous versions of duckdb will be able to read files produced by this version. 

To test that this fully works backwards compatibly, I added a test script. It iterates through all public duckdb versions and creates a `tpc-ds` database file with the version. Then the current version with this change executes a `SELECT column, COUNT(*) FROM table` for all columns and tables of `tpc-ds`.  Then it checks that the results over the files are identical. I run the script with tpc-ds sf10 to make sure that this change does not affect backwards compatibility. 

Not flattening the dictionary vectors means that all the dictionary-based optimizations can now also work on columns having null values. E.g. `SELECT DISTINCT c_birth_country FROM customer` on tpc-ds drops from 51ms to 6ms. (see attached flame chart) 

<img width="2423" height="1106" alt="image" src="https://github.com/user-attachments/assets/49210f6a-ac33-4555-9ebd-3fd43d48b08d" />

It also has a positive impact on h2oai:
```
benchmark/h2oai/group/q01.benchmark
Old timing: 0.076868
New timing: 0.025408
  ```
